### PR TITLE
Remove unused Atom types.

### DIFF
--- a/opencog/spacetime/atom-types/atom_types.script
+++ b/opencog/spacetime/atom-types/atom_types.script
@@ -3,54 +3,45 @@
 //
 
 // ====================================================================
-// SpaceServer atoms
-// XXX Review. Are any of these acutally used?
-SPACE_MAP_NODE <- NODE
-OBJECT_NODE <- NODE
-BLOCK_ENTITY_NODE <- OBJECT_NODE
-ENTITY_NODE <- OBJECT_NODE
-STRUCTURE_NODE <- OBJECT_NODE
-IMAGINARY_STRUCTURE_NODE <- OBJECT_NODE
-AT_LOCATION_LINK <- ORDERED_LINK
-
 // Time-related atoms
-// TimeNode inherits from NumerNode, so that a umeric value can be
+// TimeNode inherits from NumerNode, so that a numeric value can be
 // directly stored (wihout converting it to a string)
 TIME_NODE <- NUMBER_NODE
-TIME_INTERVAL_LINK <- ORDERED_LINK
-TIME_DOMAIN_NODE <- NODE
 AT_TIME_LINK <- ORDERED_LINK
-LATEST_LINK <- ORDERED_LINK
+AT_LOCATION_LINK <- ORDERED_LINK
+
+// ====================================================================
+// SpaceServer atoms
+// None of these are used anywhere, by anyone any more.
+// They are commented out below only so that you can find them
+// with a search-engine, if need be.
+// If you need one of these types in your code, you should define
+// it in your code, and not here!
+
+// SPACE_MAP_NODE <- NODE
+// OBJECT_NODE <- NODE
+// BLOCK_ENTITY_NODE <- OBJECT_NODE
+// ENTITY_NODE <- OBJECT_NODE
+// STRUCTURE_NODE <- OBJECT_NODE
+// IMAGINARY_STRUCTURE_NODE <- OBJECT_NODE
+
+// TIME_INTERVAL_LINK <- ORDERED_LINK
+// TIME_DOMAIN_NODE <- NODE
+// LATEST_LINK <- ORDERED_LINK
 
 // ====================================================================
 // Allen Interval algebra links
 
-// XXX TODO Perhaps "overlaps", "equals" and "contains" should be renamed
-// to make it clear that these apply to time intervals, only.
-BEFORE_LINK <- ORDERED_LINK
-OVERLAPS_LINK <- ORDERED_LINK
-DURING_LINK <- ORDERED_LINK
-MEETS_LINK <- ORDERED_LINK
-STARTS_LINK <- ORDERED_LINK
-FINISHES_LINK <- ORDERED_LINK
-EQUALS_LINK <- ORDERED_LINK
-AFTER_LINK <- ORDERED_LINK
-OVERLAPPED_BY_LINK <- ORDERED_LINK
-CONTAINS_LINK <- ORDERED_LINK
-MET_BY_LINK <- ORDERED_LINK
-STARTED_BY_LINK <- ORDERED_LINK
-FINISHED_BY_LINK <- ORDERED_LINK
-
-//
-// Other atom types for temporal representation and reasoning.
-//
-// TODO XXX: Review, and see if these are acutally being used.
-//
-PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK
-TAIL_PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK
-
-PREDICTIVE_ATTRACTION_LINK <- ORDERED_LINK
-SIMULTANEOUS_AND_LINK <- ORDERED_LINK //AND_LINK
-
-EVENTUAL_SEQUENTIAL_AND_LINK <- SEQUENTIAL_AND_LINK "EventualSequentialAND"
-EVENTUAL_PREDICTIVE_IMPLICATION_LINK <- ORDERED_LINK "EventualSequentialImplication"
+// TIME_INTERVAL_BEFORE_LINK <- ORDERED_LINK
+// TIME_INTERVAL_OVERLAPS_LINK <- ORDERED_LINK
+// TIME_INTERVAL_DURING_LINK <- ORDERED_LINK
+// TIME_INTERVAL_MEETS_LINK <- ORDERED_LINK
+// TIME_INTERVAL_STARTS_LINK <- ORDERED_LINK
+// TIME_INTERVAL_FINISHES_LINK <- ORDERED_LINK
+// TIME_INTERVAL_EQUALS_LINK <- ORDERED_LINK
+// TIME_INTERVAL_AFTER_LINK <- ORDERED_LINK
+// TIME_INTERVAL_OVERLAPPED_BY_LINK <- ORDERED_LINK
+// TIME_INTERVAL_CONTAINS_LINK <- ORDERED_LINK
+// TIME_INTERVAL_MET_BY_LINK <- ORDERED_LINK
+// TIME_INTERVAL_STARTED_BY_LINK <- ORDERED_LINK
+// TIME_INTERVAL_FINISHED_BY_LINK <- ORDERED_LINK


### PR DESCRIPTION
None of these types are used by spacetime.

Rationale:

spacetime defines a number of types that it does not need or use; it would be best to move those to the repo that needs & uses them.

Almost  all of the types in `spacetime/opencog/spacetime/atom-types/atom_types.script` are unused by spacetime. A quick grep reveals that spacetime uses only these:
```
AT_TIME_LINK
TIME_NODE
AT_LOCATION_LINK
```

As to whether spacetime or PLN should define "basic" links like `TIME_NODE`, there is an easy answer: if PLN needs access to the octree subsystem that spacetime provides, then obviously, PLN depends on spacetime.  If PLN does NOT need the octree subsystem, then it should define something like `PLN_TIME_NODE` or maybe `TEMPORAL_REASONING_NODE`, or whatever.  The spacetime version could be renamed to `SECONDS_SINCE_1970_NODE` or something like that. Maybe `TIMESTAMP_NODE` since it does not actually contain "time" it contains a timestamp of when some event was observed, with some imprecise numerical value, accurate to maybe 10 milliseconds with the current octree code. 

The robot code used to use `TIME_NODE` also, but it did not store seconds, I think it stored nanoseconds.

Moral of the story: different subsystems have a different idea of what "time" is, and those subsystems should be free to define time as they need it. Trying to force all of them to use a single common definition is going to just create problems.  Someday in the future, if/when things get more stable and usable, we can revisit this question. For now, its best to keep things as simple as possible.  