### PR TITLE
Link the Python wrapper with `--no-as-needed`

### DIFF
--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -45,6 +45,7 @@ ADD_LIBRARY(spacetime_cython SHARED
 ADD_DEPENDENCIES(spacetime_cython spacetime-types)
 
 TARGET_LINK_LIBRARIES(spacetime_cython
+	${NO_AS_NEEDED}
 	spacetime-types
 	${ATOMSPACE_LIBRARIES}
 	${PYTHON_LIBRARIES}


### PR DESCRIPTION
Same fix as for the opencog/pln#43.